### PR TITLE
[BUG] fixes handling of decimals when submitting token mint quantity

### DIFF
--- a/src/components/mint-tokens/index.tsx
+++ b/src/components/mint-tokens/index.tsx
@@ -20,6 +20,7 @@ import {
   getTxBuilder,
   BASE_FEE,
   XLM_DECIMALS,
+  getTokenDecimals,
   getTokenSymbol,
   getServer,
   submitTx,
@@ -59,21 +60,14 @@ export const MintToken = (props: MintTokenProps) => {
   const [isLoadingTokenDetails, setIsLoadingTokenDetails] =
     React.useState<boolean>(false);
 
-  // Not using vals yet
-  /* eslint-disable */
-  // @ts-ignore
   const [tokenId, setTokenId] = React.useState("");
-  // @ts-ignore
   const [tokenDecimals, setTokenDecimals] = React.useState(XLM_DECIMALS);
   const [tokenDestination, setTokenDestination] = React.useState("");
-  // @ts-ignore
   const [tokenSymbol, setTokenSymbol] = React.useState("");
-  // @ts-ignore
   const [quantity, setQuantity] = React.useState("");
   const [txResultXDR, setTxResultXDR] = React.useState("");
   const [signedXdr, setSignedXdr] = React.useState("");
   const [isSubmitting, setIsSubmitting] = React.useState(false);
-  /* eslint-enable */
 
   async function setToken(id: string) {
     setIsLoadingTokenDetails(true);
@@ -91,6 +85,16 @@ export const MintToken = (props: MintTokenProps) => {
 
       const symbol = await getTokenSymbol(id, txBuilderAdmin, server);
       setTokenSymbol(symbol);
+
+      const txBuilderDecimals = await getTxBuilder(
+        activePubKey!,
+        BASE_FEE,
+        server,
+        activeNetworkDetails.networkPassphrase,
+      );
+      const decimals = await getTokenDecimals(id, txBuilderDecimals, server);
+      setTokenDecimals(decimals);
+      setIsLoadingTokenDetails(false);
 
       return true;
     } catch (error) {
@@ -162,6 +166,7 @@ export const MintToken = (props: MintTokenProps) => {
             fee={fee}
             memo={memo}
             networkDetails={activeNetworkDetails}
+            tokenDecimals={tokenDecimals}
           />
         );
       }

--- a/src/components/mint-tokens/token-confirmation.tsx
+++ b/src/components/mint-tokens/token-confirmation.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Button, Heading, Profile } from "@stellar/design-system";
 import { NetworkDetails, signTx } from "../../helpers/network";
-import { mintTokens, getTxBuilder, getServer } from "../../helpers/soroban";
+import { mintTokens, getTxBuilder, getServer, parseTokenAmount } from "../../helpers/soroban";
 
 interface ConfirmMintTxProps {
   quantity: string;
@@ -12,13 +12,14 @@ interface ConfirmMintTxProps {
   network: string;
   onTxSign: (xdr: string) => void;
   tokenId: string;
+  tokenDecimals: number;
   tokenSymbol: string;
   networkDetails: NetworkDetails;
 }
 
 export const ConfirmMintTx = (props: ConfirmMintTxProps) => {
   const signWithFreighter = async () => {
-    const quantity = parseFloat(props.quantity);
+    const quantity = parseTokenAmount(props.quantity, props.tokenDecimals);
     const server = getServer(props.networkDetails);
     const txBuilderAdmin = await getTxBuilder(
       props.pubKey,
@@ -29,7 +30,7 @@ export const ConfirmMintTx = (props: ConfirmMintTxProps) => {
 
     const xdr = await mintTokens({
       tokenId: props.tokenId,
-      quantity,
+      quantity: quantity.toNumber(),
       destinationPubKey: props.destination,
       memo: props.memo,
       txBuilderAdmin,

--- a/src/helpers/soroban.ts
+++ b/src/helpers/soroban.ts
@@ -272,6 +272,21 @@ export const getTokenName = async (
   return result;
 };
 
+export const getTokenDecimals = async (
+  tokenId: string,
+  txBuilder: TransactionBuilder,
+  server: Server,
+) => {
+  const contract = new Contract(tokenId);
+  const tx = txBuilder
+    .addOperation(contract.call("decimals"))
+    .setTimeout(TimeoutInfinite)
+    .build();
+
+  const result = await simulateTx<number>(tx, decoders.u32, server);
+  return result;
+};
+
 export const mintTokens = async ({
   tokenId,
   quantity,


### PR DESCRIPTION
This adds missing use of token decimals in order to send the correct string when minting tokens, without using the token decimals we interpret the users input as exactly what they want to mean when in practice they enter the string into field using the notation that matches the tokens set number of decimals.

Example-
Is user enter in `5.50` when they want to mint more of a 7 decimal token, we should be sending the string `55000000`