### PR TITLE
move token warning to step 3 (token id) instead of on all steps

### DIFF
--- a/src/components/mint-tokens/index.tsx
+++ b/src/components/mint-tokens/index.tsx
@@ -269,12 +269,14 @@ export const MintToken = (props: MintTokenProps) => {
         )}
       </div>
       <div className="Layout__inset layout">
-        <div className="admin-banner-container">
-          <Notification
-            title="Account must be an admin of the token"
-            variant="primary"
-          />
-        </div>
+        {stepCount === 3 && (
+          <div className="admin-banner-container">
+            <Notification
+              title="Account must be an admin of the token"
+              variant="primary"
+            />
+          </div>
+        )}
         <div className="mint-token">
           <Card variant="primary">
             <Caption size="sm" addlClassName="step-count">


### PR DESCRIPTION
Instead of showing `Account must be an admin of the token` warning on all steps, only display it on the relevant step, which is "Step 3: Choose Token to Mint"

Screenshots:
![fix-01](https://github.com/stellar/soroban-react-mint-token/assets/3912060/83bc07df-856b-4688-94c4-10fa14225e0e)
![fix-02](https://github.com/stellar/soroban-react-mint-token/assets/3912060/2abcd024-378a-40c0-aa13-88bf39be4d43)
