### PR TITLE
adds estimated fee calc for default fee value

### DIFF
--- a/src/components/mint-tokens/index.tsx
+++ b/src/components/mint-tokens/index.tsx
@@ -16,6 +16,7 @@ import {
   ISupportedWallet,
 } from "stellar-wallets-kit";
 
+import { stroopToXlm } from "helpers/format";
 import { FUTURENET_DETAILS } from "../../helpers/network";
 import { ERRORS } from "../../helpers/error";
 import {
@@ -158,7 +159,7 @@ export const MintToken = (props: MintTokenProps) => {
         builder,
         server,
       );
-      setFee(estimatedFee);
+      setFee(stroopToXlm(estimatedFee).toString());
       setIsGettingFee(false);
     } catch (error) {
       // defaults to hardcoded base fee if this fails

--- a/src/components/mint-tokens/token-confirmation.tsx
+++ b/src/components/mint-tokens/token-confirmation.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Button, Heading, Profile } from "@stellar/design-system";
 import { StellarWalletsKit } from "stellar-wallets-kit";
+import { xlmToStroop } from "helpers/format";
 import { NetworkDetails, signTx } from "../../helpers/network";
 import { mintTokens, getTxBuilder, getServer, parseTokenAmount } from "../../helpers/soroban";
 import { ERRORS } from "../../helpers/error";
@@ -29,7 +30,7 @@ export const ConfirmMintTx = (props: ConfirmMintTxProps) => {
      // Gets a transaction builder and use it to add a "mint" operation and build the corresponding XDR
     const txBuilderAdmin = await getTxBuilder(
       props.pubKey,
-      props.fee,
+      xlmToStroop(props.fee).toString(),
       server,
       props.networkDetails.networkPassphrase,
     );

--- a/src/components/mint-tokens/token-transaction.tsx
+++ b/src/components/mint-tokens/token-transaction.tsx
@@ -25,7 +25,7 @@ export const TokenTransaction = (props: TokenInputProps) => {
       <Input
         fieldSize="md"
         id="input-fee"
-        label="Estimated Fee"
+        label="Estimated Fee (XLM)"
         value={props.fee}
         onChange={handleFeeChange}
       />

--- a/src/helpers/format.ts
+++ b/src/helpers/format.ts
@@ -14,6 +14,14 @@ export const stroopToXlm = (
   return new BigNumber(Number(stroops) / 1e7);
 };
 
+export const xlmToStroop = (lumens: BigNumber | string): BigNumber => {
+  if (lumens instanceof BigNumber) {
+    return lumens.times(1e7);
+  }
+  // round to nearest stroop
+  return new BigNumber(Math.round(Number(lumens) * 1e7));
+};
+
 // With a tokens set number of decimals, display the formatted value for an amount.
 // Example - User A has 1000000001 of a token set to 7 decimals, display should be 100.0000001
 export const formatTokenAmount = (amount: BigNumber, decimals: number) => {


### PR DESCRIPTION
Ticket: https://stellarorg.atlassian.net/jira/software/c/projects/WAL/boards/67?modal=detail&selectedIssue=WAL-904

This adds a getEstimatedFee to be used in the step before the fee step to fetch the estimated fee once we have all of the tx details.

Open Question
The fee is set in stroops, should we be displaying the value in stroops to the user or should we display it in lumens and let the user set the value in lumens?