### PR TITLE
Replace formatters and parser with the new sdk version

### DIFF
--- a/src/components/mint-tokens/token-confirmation.tsx
+++ b/src/components/mint-tokens/token-confirmation.tsx
@@ -1,14 +1,10 @@
 import React from "react";
 import { Button, Heading, Profile } from "@stellar/design-system";
+import Soroban from "soroban-client";
 import { StellarWalletsKit } from "stellar-wallets-kit";
 import { xlmToStroop } from "../../helpers/format";
 import { NetworkDetails, signTx } from "../../helpers/network";
-import {
-  mintTokens,
-  getTxBuilder,
-  getServer,
-  parseTokenAmount,
-} from "../../helpers/soroban";
+import { mintTokens, getTxBuilder, getServer } from "../../helpers/soroban";
 import { ERRORS } from "../../helpers/error";
 
 interface ConfirmMintTxProps {
@@ -29,7 +25,10 @@ interface ConfirmMintTxProps {
 export const ConfirmMintTx = (props: ConfirmMintTxProps) => {
   const signWithFreighter = async () => {
     // Need to use the perviously fetched token decimals to properly display the quantity value
-    const quantity = parseTokenAmount(props.quantity, props.tokenDecimals);
+    const quantity = Soroban.parseTokenAmount(
+      props.quantity,
+      props.tokenDecimals,
+    );
     // Get an instance of a Soroban RPC set to the selected network
     const server = getServer(props.networkDetails);
     // Gets a transaction builder and use it to add a "mint" operation and build the corresponding XDR

--- a/src/helpers/format.ts
+++ b/src/helpers/format.ts
@@ -21,24 +21,3 @@ export const xlmToStroop = (lumens: BigNumber | string): BigNumber => {
   // round to nearest stroop
   return new BigNumber(Math.round(Number(lumens) * 1e7));
 };
-
-// With a tokens set number of decimals, display the formatted value for an amount.
-// Example - User A has 1000000001 of a token set to 7 decimals, display should be 100.0000001
-export const formatTokenAmount = (amount: BigNumber, decimals: number) => {
-  let formatted = amount.toString();
-
-  if (decimals > 0) {
-    formatted = amount.shiftedBy(-decimals).toFixed(decimals).toString();
-
-    // Trim trailing zeros
-    while (formatted[formatted.length - 1] === "0") {
-      formatted = formatted.substring(0, formatted.length - 1);
-    }
-
-    if (formatted.endsWith(".")) {
-      formatted = formatted.substring(0, formatted.length - 1);
-    }
-  }
-
-  return formatted;
-};

--- a/src/helpers/soroban.ts
+++ b/src/helpers/soroban.ts
@@ -13,7 +13,6 @@ import {
   TransactionBuilder,
   xdr,
 } from "soroban-client";
-import BigNumber from "bignumber.js";
 import { NetworkDetails } from "./network";
 import { stroopToXlm } from "./format";
 import { ERRORS } from "./error";
@@ -44,40 +43,6 @@ export const accountToScVal = (account: string) =>
 // Can be used whenever you need an i128 argument for a contract method
 export const numberToI128 = (value: number): xdr.ScVal =>
   nativeToScVal(value, { type: "i128" });
-
-// Given a display value for a token and a number of decimals, return the correspding BigNumber
-export const parseTokenAmount = (value: string, decimals: number) => {
-  const comps = value.split(".");
-
-  let whole = comps[0];
-  let fraction = comps[1];
-  if (!whole) {
-    whole = "0";
-  }
-  if (!fraction) {
-    fraction = "0";
-  }
-
-  // Trim trailing zeros
-  while (fraction[fraction.length - 1] === "0") {
-    fraction = fraction.substring(0, fraction.length - 1);
-  }
-
-  // If decimals is 0, we have an empty string for fraction
-  if (fraction === "") {
-    fraction = "0";
-  }
-
-  // Fully pad the string with zeros to get to value
-  while (fraction.length < decimals) {
-    fraction += "0";
-  }
-
-  const wholeValue = new BigNumber(whole);
-  const fractionValue = new BigNumber(fraction);
-
-  return wholeValue.shiftedBy(decimals).plus(fractionValue);
-};
 
 // Get a server configfured for a specific network
 export const getServer = (networkDetails: NetworkDetails) =>


### PR DESCRIPTION
Ticket: [Remove formatters and parser from soroban-react-mint-token and use new sdk version](https://stellarorg.atlassian.net/browse/WAL-990)

**Summary:**
- removed `formatTokenAmount` since we don't use it anywhere else in the project
- replaced `parseTokenAmount` with `Soroban.parseTokenAmount`